### PR TITLE
Several improvements and fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,24 @@
+# Changelog
+
+### 0.X.X
+
+### New features
+
+* Add `mva` argument to `flexitext()` which controls the vertical alignment of individual texts within the outer text box (5da272172874fc89e54c4bf112a237dadb37062a).
+
+### Maintenance and fixes
+
+* Improve backgroundcolor behavior. The backgroundcolor of one piece of text does not overlap other pieces of text (32787dfe0e60c57154f99ffe09011c5e7fd6367a).
+* Add `pyproject.toml` (#9).
+* Numbers like X. are interpreted as X.0 floats (e.g. `1.`). Flexitext attempted to parse them as two numbers, resulting in an error (#9).
+* Add `Changelog.md` (#9).
+* Improved test coverage (#9).
+
+### Documentation
+
+### Deprecation
+
+### 0.1.0
+
+This is the initial release
+

--- a/flexitext/flexitext.py
+++ b/flexitext/flexitext.py
@@ -103,7 +103,15 @@ class FlexiText:
 
 
 def flexitext(
-    x, y, s, ha="left", va="center", ma="left", mva="baseline", xycoords="axes fraction", ax=None
+    x,
+    y,
+    s,
+    ha="left",
+    va="center",
+    ma="left",
+    mva="baseline",
+    xycoords="axes fraction",
+    ax=None,
 ):
     """Draw text with multiple formats.
 

--- a/flexitext/parser/args.py
+++ b/flexitext/parser/args.py
@@ -13,10 +13,13 @@ class ArgScanner(Scanner):
         elif char == ",":
             self.add_token("COMMA")
         elif char == ".":
-            if self.peek().isdigit():
+            next_char = self.peek()
+            if next_char.isdigit():
                 self.floatnum()
+            elif next_char == "":  # pragma: no cover
+                raise ScanError("Unexpected EOF when declaring a number")
             else:
-                raise ScanError(f"Unexpected character: {char}")
+                raise ScanError(f"Unexpected character when declaring a number: {next_char}")
         elif char == ":":
             self.add_token("COLON")
         elif char.isdigit():
@@ -35,7 +38,8 @@ class ArgScanner(Scanner):
         is_float = False
         while self.peek().isdigit():
             self.advance()
-        if self.peek() == "." and self.peek_next().isdigit():
+        # Works with both 1. and 1.0 like numbers.
+        if self.peek() == ".":
             is_float = True
             self.advance()
             while self.peek().isdigit():

--- a/flexitext/parser/classes/scanner.py
+++ b/flexitext/parser/classes/scanner.py
@@ -21,7 +21,7 @@ class Scanner:
         return self.text[self.current]
 
     def peek_next(self):
-        if self.current + 1 >= len(self.text):
+        if self.current + 1 >= len(self.text):  # pragma: no cover
             return ""
         return self.text[self.current + 1]
 
@@ -36,5 +36,5 @@ class Scanner:
         self.tokens.append(Token("EOF", ""))
         return self
 
-    def scan_token(self):
+    def scan_token(self):  # pragma: no cover
         return None

--- a/flexitext/parser/classes/token.py
+++ b/flexitext/parser/classes/token.py
@@ -4,7 +4,7 @@ class Token:
         self.lexeme = lexeme
         self.literal = literal
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         string_list = [
             f"kind: {self.kind}",
             f"lexeme: {self.lexeme}",

--- a/flexitext/tests/parser/test_make_texts.py
+++ b/flexitext/tests/parser/test_make_texts.py
@@ -6,7 +6,8 @@ from flexitext.parser import make_texts
 def test_make_texts():
     text = "<what:ever>My text</>"
     with pytest.raises(
-        TypeError, match=re.escape("__init__() got an unexpected keyword argument 'what'")
+        TypeError,
+        match=re.escape("__init__() got an unexpected keyword argument 'what'"),
     ):
         make_texts(text)
 

--- a/flexitext/tests/test_flexitext.py
+++ b/flexitext/tests/test_flexitext.py
@@ -9,7 +9,7 @@ from flexitext import flexitext
 # These tests are quite poor for now
 def test_flexitext():
     text = "<color:green, alpha:0.3>a piece of text</>"
-    _, ax = plt.subplots()
+    _, _ = plt.subplots()
     box = flexitext(0.5, 0.5, text)
     assert isinstance(box, AnnotationBbox)
 

--- a/flexitext/tests/test_style.py
+++ b/flexitext/tests/test_style.py
@@ -24,3 +24,6 @@ def test_style():
     style = Style(**props)
     assert repr(style).count("\n") == len(props) + 1
     assert style != props
+
+    # This is always None, unless the user changes _backgroundcolor by hand.
+    assert style.backgroundcolor is None

--- a/flexitext/tests/test_textgrid.py
+++ b/flexitext/tests/test_textgrid.py
@@ -28,7 +28,11 @@ def test_make_grid():
 
 def test_make_text_grid():
     style = Style(color="red")
-    texts = [Text("my\ntext", style), Text("other text\n", style), Text("and another one", style)]
+    texts = [
+        Text("my\ntext", style),
+        Text("other text\n", style),
+        Text("and another one", style),
+    ]
     text_grid = make_text_grid(texts)
 
     assert isinstance(text_grid, VPacker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 100
+target-version = ['py37', 'py38']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
+black==21.9b0
 pylint==2.10.2
-black>=20.8b1
-pytest>=4.4.0
 pytest-cov>=2.6.1
+pytest>=4.4.0


### PR DESCRIPTION
* Modify dev requirements and sort them alphabetically.
* Add pyproject.toml where we set the length of the black formatter.
* Flexitext now parses floats like 2. as 2.0. Previously it tried to parse two different numbers, resulting in an error.
* Increase coverage to 100%. 
* Added changelog.